### PR TITLE
The point at infinity is only representable in the jacobian at y = 1.

### DIFF
--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -315,10 +315,14 @@ impl<P: GroupParams> Neg for G<P> {
     type Output = G<P>;
 
     fn neg(self) -> G<P> {
-        G {
-            x: self.x,
-            y: -self.y,
-            z: self.z
+        if self.is_zero() {
+            self
+        } else {
+            G {
+                x: self.x,
+                y: -self.y,
+                z: self.z
+            }
         }
     }
 }


### PR DESCRIPTION
(From upstream.) The y coordinate shouldn't be negated if it's zero.

This doesn't break any API invariants, but it does look like you're changing the library to expose more things.

See also https://github.com/scipr-lab/libsnark/issues/60.