### PR TITLE
The point at infinity is only representable in the jacobian at y = 1

### DIFF
--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -948,3 +948,11 @@ fn affine_ok() {
     let res = AffineG1::new(Fq::one(), G1Params::coeff_b());
     assert!(res.is_err(), "Affine initialization should be ok because the point is on the curve");    
 }
+
+fn test_y_at_point_at_infinity() {
+    assert!(G1::zero().y == Fq::one());
+    assert!((-G1::zero()).y == Fq::one());
+
+    assert!(G2::zero().y == Fq2::one());
+    assert!((-G2::zero()).y == Fq2::one());
+}

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -383,10 +383,14 @@ impl<P: GroupParams> Neg for G<P> {
     type Output = G<P>;
 
     fn neg(self) -> G<P> {
-        G {
-            x: self.x,
-            y: -self.y,
-            z: self.z
+        if self.is_zero() {
+            self
+        } else {
+            G {
+                x: self.x,
+                y: -self.y,
+                z: self.z
+            }
         }
     }
 }


### PR DESCRIPTION
(From upstream.) The y coordinate shouldn't be negated if it's zero.

This doesn't break any API invariants, but it does look like you're changing the library to expose more things.

See also https://github.com/scipr-lab/libsnark/issues/60.

Supersedes #1