### PR TITLE
use u128 for bigint limbs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["rustc-serialize"]
 name = "api"
 
 [dependencies]
-rand = "0.4"
+rand = "0.5"
 rustc-serialize = { version = "0.3", optional = true }
 byteorder = "1.0"
 crunchy = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ default = ["rustc-serialize"]
 name = "api"
 
 [dependencies]
-rand = "0.5"
+rand = { version = "0.5", features = ["i128_support"] }
 rustc-serialize = { version = "0.3", optional = true }
-byteorder = "1.0"
+byteorder = { version = "1.0", features = ["i128"] }
 crunchy = "0.2.1"
 
 [dev-dependencies.bincode]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -16,7 +16,7 @@ macro_rules! field_impl {
         impl From<$name> for U256 {
             #[inline]
             fn from(mut a: $name) -> Self {
-                a.0.mul(&U256::one(), &U256($modulus), $inv);
+                a.0.mul(&U256::one(), &U256::from($modulus), $inv);
 
                 a.0
             }
@@ -63,8 +63,8 @@ macro_rules! field_impl {
 
             /// Converts a U256 to an Fp so long as it's below the modulus.
             pub fn new(mut a: U256) -> Option<Self> {
-                if a < U256($modulus) {
-                    a.mul(&U256($rsquared), &U256($modulus), $inv);
+                if a < U256::from($modulus) {
+                    a.mul(&U256::from($rsquared), &U256::from($modulus), $inv);
 
                     Some($name(a))
                 } else {
@@ -75,7 +75,7 @@ macro_rules! field_impl {
             /// Converts a U256 to an Fr regardless of modulus.
             pub fn new_mul_factor(mut a: U256) -> Option<Self> {
                 if true {
-                    a.mul(&U256($rsquared), &U256($modulus), $inv);
+                    a.mul(&U256::from($rsquared), &U256::from($modulus), $inv);
                     Some($name(a))
                 } else {
                     None
@@ -83,19 +83,19 @@ macro_rules! field_impl {
             }
 
             pub fn interpret(buf: &[u8; 64]) -> Self {
-                $name::new(U512::interpret(buf).divrem(&U256($modulus)).1).unwrap()
+                $name::new(U512::interpret(buf).divrem(&U256::from($modulus)).1).unwrap()
             }
 
             /// Returns the modulus
             #[inline]
             #[allow(dead_code)]
             pub fn modulus() -> U256 {
-                U256($modulus)
+                U256::from($modulus)
             }
 
             #[inline]
             #[allow(dead_code)]
-            pub fn inv(&self) -> u64 {
+            pub fn inv(&self) -> u128 {
                 $inv
             }
 
@@ -107,16 +107,16 @@ macro_rules! field_impl {
         impl FieldElement for $name {
             #[inline]
             fn zero() -> Self {
-                $name(U256([0, 0, 0, 0]))
+                $name(U256::from([0, 0, 0, 0]))
             }
 
             #[inline]
             fn one() -> Self {
-                $name(U256($one))
+                $name(U256::from($one))
             }
 
             fn random<R: Rng>(rng: &mut R) -> Self {
-                $name(U256::random(rng, &U256($modulus)))
+                $name(U256::random(rng, &U256::from($modulus)))
             }
 
             #[inline]
@@ -128,8 +128,8 @@ macro_rules! field_impl {
                 if self.is_zero() {
                     None
                 } else {
-                    self.0.invert(&U256($modulus));
-                    self.0.mul(&U256($rcubed), &U256($modulus), $inv);
+                    self.0.invert(&U256::from($modulus));
+                    self.0.mul(&U256::from($rcubed), &U256::from($modulus), $inv);
 
                     Some(self)
                 }
@@ -141,7 +141,7 @@ macro_rules! field_impl {
 
             #[inline]
             fn add(mut self, other: $name) -> $name {
-                self.0.add(&other.0, &U256($modulus));
+                self.0.add(&other.0, &U256::from($modulus));
 
                 self
             }
@@ -152,7 +152,7 @@ macro_rules! field_impl {
 
             #[inline]
             fn sub(mut self, other: $name) -> $name {
-                self.0.sub(&other.0, &U256($modulus));
+                self.0.sub(&other.0, &U256::from($modulus));
 
                 self
             }
@@ -163,7 +163,7 @@ macro_rules! field_impl {
 
             #[inline]
             fn mul(mut self, other: $name) -> $name {
-                self.0.mul(&other.0, &U256($modulus), $inv);
+                self.0.mul(&other.0, &U256::from($modulus), $inv);
 
                 self
             }
@@ -174,7 +174,7 @@ macro_rules! field_impl {
 
             #[inline]
             fn neg(mut self) -> $name {
-                self.0.neg(&U256($modulus));
+                self.0.neg(&U256::from($modulus));
 
                 self
             }
@@ -208,7 +208,7 @@ field_impl!(
         0x666ea36f7879462e,
         0xe0a77c19a07df2f
     ],
-    0xc2e1f593efffffff
+    0x6586864b4c6911b3c2e1f593efffffff
 );
 
 field_impl!(
@@ -237,12 +237,12 @@ field_impl!(
         0x666ea36f7879462c,
         0xe0a77c19a07df2f
     ],
-    0x87d20782e4866389
+    0x9ede7d651eca6ac987d20782e4866389
 );
 
 #[inline]
 pub fn const_fq(i: [u64; 4]) -> Fq {
-    Fq(U256(i))
+    Fq(U256::from(i))
 }
 
 #[test]

--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -120,7 +120,7 @@ impl Fq12 {
     }
 
     pub fn exp_by_neg_z(&self) -> Fq12 {
-        self.cyclotomic_pow(U256([4965661367192848881, 0, 0, 0]))
+        self.cyclotomic_pow(U256::from([4965661367192848881, 0, 0, 0]))
             .unitary_inverse()
     }
 

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -50,7 +50,7 @@ impl Encodable for Fq2 {
         let c0: U256 = self.c0.into();
         let c1: U256 = self.c1.into();
 
-        U512::from(&c1, &c0, &Fq::modulus()).encode(s)
+        U512::new(&c1, &c0, &Fq::modulus()).encode(s)
     }
 }
 

--- a/src/fields/tests.rs
+++ b/src/fields/tests.rs
@@ -114,8 +114,13 @@ pub fn field_trials<F: FieldElement>() {
     assert_eq!(-F::one() + F::one(), F::zero());
     assert_eq!(F::zero() - F::zero(), F::zero());
 
-    let seed: [usize; 4] = [103245, 191922, 1293, 192103];
-    let mut rng = StdRng::from_seed(&seed);
+    let seed = [
+        0, 0, 0, 0, 0, 0, 64, 13, // 103245
+        0, 0, 0, 0, 0, 0, 176, 2, // 191922
+        0, 0, 0, 0, 0, 0, 0, 13, // 1293
+        0, 0, 0, 0, 0, 0, 96, 7u8, // 192103
+    ];
+    let mut rng = StdRng::from_seed(seed);
 
     rand_element_squaring::<F, StdRng>(&mut rng);
     rand_element_addition_and_negation::<F, StdRng>(&mut rng);

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -574,7 +574,7 @@ fn two_inv() -> Fq {
 
 #[inline]
 fn ate_loop_count() -> U256 {
-    U256([
+    U256::from([
         0x9d797039be763ba8,
         0x0000000000000001,
         0x0000000000000000,

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -1038,8 +1038,13 @@ fn predefined_pair() {
 #[test]
 fn test_binlinearity() {
     use rand::{SeedableRng, StdRng};
-    let seed: [usize; 4] = [103245, 191922, 1293, 192103];
-    let mut rng = StdRng::from_seed(&seed);
+    let seed = [
+        0, 0, 0, 0, 0, 0, 64, 13, // 103245
+        0, 0, 0, 0, 0, 0, 176, 2, // 191922
+        0, 0, 0, 0, 0, 0, 0, 13, // 1293
+        0, 0, 0, 0, 0, 0, 96, 7u8, // 192103
+    ];
+    let mut rng = StdRng::from_seed(seed);
 
     for _ in 0..50 {
         let p = G1::random(&mut rng);

--- a/src/groups/tests.rs
+++ b/src/groups/tests.rs
@@ -91,8 +91,13 @@ pub fn group_trials<G: GroupElement>() {
     assert!((G::one() * (-Fr::one()) + G::one()).is_zero());
 
     use rand::{SeedableRng, StdRng};
-    let seed: [usize; 4] = [103245, 191922, 1293, 192103];
-    let mut rng = StdRng::from_seed(&seed);
+    let seed = [
+        0, 0, 0, 0, 0, 0, 64, 13, // 103245
+        0, 0, 0, 0, 0, 0, 176, 2, // 191922
+        0, 0, 0, 0, 0, 0, 0, 13, // 1293
+        0, 0, 0, 0, 0, 0, 96, 7u8, // 192103
+    ];
+    let mut rng = StdRng::from_seed(seed);
 
     random_test_addition::<G, _>(&mut rng);
     random_test_doubling::<G, _>(&mut rng);


### PR DESCRIPTION
This PR updates the bigints (`U512` and `U256`) to use `u128` for limbs.
The fields' inverses were defined over `2^64` so I had to extend them to `2^128`.

benchcmp
```
name                         control ns/iter  variable ns/iter  diff ns/iter   diff %  speedup
 fq12_exponentiation          4,544,644        2,338,371           -2,206,273  -48.55%   x 1.94
 fq12_scalar_multiplication   14,569           7,125                   -7,444  -51.09%   x 2.04
 fr_addition                  17               13                          -4  -23.53%   x 1.31
 fr_inverses                  8,711            5,531                   -3,180  -36.51%   x 1.57
 fr_multiplication            104              41                         -63  -60.58%   x 2.54
 fr_subtraction               20               14                          -6  -30.00%   x 1.43
 g1_addition                  1,805            756                     -1,049  -58.12%   x 2.39
 g1_deserialization           768              482                       -286  -37.24%   x 1.59
 g1_scalar_multiplication     481,975          212,330               -269,645  -55.95%   x 2.27
 g1_serialization             9,898            6,428                   -3,470  -35.06%   x 1.54
 g1_serialization_normalized  549              431                       -118  -21.49%   x 1.27
 g1_subtraction               1,872            771                     -1,101  -58.81%   x 2.43
 g2_addition                  8,440            3,768                   -4,672  -55.36%   x 2.24
 g2_deserialization           1,776,474        864,284               -912,190  -51.35%   x 2.06
 g2_scalar_multiplication     2,056,874        983,488             -1,073,386  -52.19%   x 2.09
 g2_serialization             12,477           7,628                   -4,849  -38.86%   x 1.64
 g2_serialization_normalized  1,039            752                       -287  -27.62%   x 1.38
 g2_subtraction               8,388            3,820                   -4,568  -54.46%   x 2.20
 perform_pairing              5,315,023        2,644,591           -2,670,432  -50.24%   x 2.01
```