### PR TITLE
added efficient batch pairing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,6 +616,16 @@ pub fn pairing(p: G1, q: G2) -> Gt {
     Gt(groups::pairing(&p.0, &q.0))
 }
 
+pub fn pairing_batch(pairs: &[(G1, G2)]) -> Gt {
+    let mut ps : Vec<groups::G1> = vec![];
+    let mut qs : Vec<groups::G2> = vec![];
+    for (p, q) in pairs {
+        ps.push(p.0);
+        qs.push(q.0);
+    }
+    Gt(groups::pairing_batch(&ps, &qs))
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]


### PR DESCRIPTION
Hello there!  

We've been discussing the parity bn library in the EIP-1829 telegram channel, and noticed that pairing algorithm has some noticeable areas that could be sped up.  

Specifically, the 'final exponentiation' step in a bilinear pairing only needs to be computed once for a batch of pairings. In addition, a significant portion of the 'miller loop' algorithm only needs to be performed once for a batch of pairings.  

As currently implemented, these computationally intensive steps were being performed for every pair of points passed to the library.  

I have put together a small algorithm that computes a bilinear pairing for a batch of points that takes advantage of these speedups. The resulting algorithm is at least 2x faster when computing a pairing of 10 points, which is fairly significant.  

I'm quite unfamiliar with Rust, so if there are any changes that need to be made to the PR I would be happy to make them. @shamatar from matter labs has also been hacking away at this with me, and also has a solution at https://github.com/shamatar/bn  

Cheers,
Zac.