### PR TITLE
Make bn no_std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,15 @@ default = ["rustc-serialize"]
 name = "api"
 
 [dependencies]
-rand = { version = "0.5", features = ["i128_support"] }
+rand = { version = "0.5", features = ["i128_support"], default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
-byteorder = { version = "1.0", features = ["i128"] }
+byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
-lazy_static = "*"
-rustc-hex = "2"
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
+rustc-hex = { version = "2", default-features = false }
+
+[dev-dependencies]
+rand = { version = "0.5", features = ["i128_support"] }
 
 [dev-dependencies.bincode]
 version = "0.6"

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 use rand::Rng;
 
 #[cfg(feature = "rustc-serialize")]

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -1,11 +1,11 @@
+use alloc::vec::Vec;
+use core::ops::{Add, Mul, Neg, Sub};
 use rand::Rng;
-use std::ops::{Add, Mul, Neg, Sub};
-use super::FieldElement;
+use fields::FieldElement;
+use arith::{U256, U512};
 
 #[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-
-use arith::{U256, U512};
 
 macro_rules! field_impl {
     ($name:ident, $modulus:expr, $rsquared:expr, $rcubed:expr, $one:expr, $inv:expr) => {

--- a/src/fields/fq12.rs
+++ b/src/fields/fq12.rs
@@ -1,7 +1,6 @@
-use fields::{const_fq, FieldElement, Fq, Fq2, Fq6};
-use std::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 use rand::Rng;
-
+use fields::{const_fq, FieldElement, Fq, Fq2, Fq6};
 use arith::U256;
 
 fn frobenius_coeffs_c1(power: usize) -> Fq2 {

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -1,7 +1,6 @@
-use fields::{const_fq, FieldElement, Fq};
-use std::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 use rand::Rng;
-
+use fields::{const_fq, FieldElement, Fq};
 use arith::{U256, U512};
 
 #[cfg(feature = "rustc-serialize")]

--- a/src/fields/fq6.rs
+++ b/src/fields/fq6.rs
@@ -1,5 +1,5 @@
 use fields::{const_fq, FieldElement, Fq, Fq2};
-use std::ops::{Add, Mul, Neg, Sub};
+use core::ops::{Add, Mul, Neg, Sub};
 use rand::Rng;
 
 fn frobenius_coeffs_c1(n: usize) -> Fq2 {

--- a/src/fields/mod.rs
+++ b/src/fields/mod.rs
@@ -5,8 +5,8 @@ mod fq12;
 
 use arith::U256;
 use rand::Rng;
-use std::ops::{Add, Mul, Neg, Sub};
-use std::fmt::Debug;
+use core::ops::{Add, Mul, Neg, Sub};
+use alloc::fmt::Debug;
 
 pub use self::fp::{const_fq, Fq, Fr};
 pub use self::fq2::{Fq2, fq2_nonresidue};

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -1,8 +1,8 @@
-use std::ops::{Add, Mul, Neg, Sub};
 use fields::{const_fq, FieldElement, Fq, Fq12, Fq2, Fr, fq2_nonresidue};
 use arith::U256;
-use std::fmt;
+use core::{fmt, ops::{Add, Mul, Neg, Sub}};
 use rand::Rng;
+use alloc::vec::Vec;
 
 #[cfg(feature = "rustc-serialize")]
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -661,7 +661,7 @@ impl G2Precomp {
     }
 }
 
-fn miller_loop_batch(g2_precomputes: &Vec<G2Precomp>, g1_vec: &Vec<AffineG<G1Params>>) -> Fq12 {
+pub fn miller_loop_batch(g2_precomputes: &Vec<G2Precomp>, g1_vec: &Vec<AffineG<G1Params>>) -> Fq12 {
     let mut f = Fq12::one();
 
     let mut idx = 0;
@@ -957,8 +957,8 @@ pub fn pairing(p: &G1, q: &G2) -> Fq12 {
 }
 
 pub fn pairing_batch(ps: &[G1], qs: &[G2]) -> Fq12 {
-    let mut p_affines: Vec<AffineG<G1Params>> = vec![];
-    let mut q_precomputes: Vec<G2Precomp> = vec![];
+    let mut p_affines: Vec<AffineG<G1Params>> = Vec::new();
+    let mut q_precomputes: Vec<G2Precomp> = Vec::new();
     for (p, q) in ps.into_iter().zip(qs.into_iter()) {
 
         let p_affine = p.to_affine();
@@ -1088,8 +1088,8 @@ fn predefined_pair() {
 
 #[test]
 fn test_batch_bilinearity_empty() {
-    let p_vec : Vec<G1> = vec![];
-    let q_vec : Vec<G2> = vec![];
+    let p_vec : Vec<G1> = Vec::new();
+    let q_vec : Vec<G2> = Vec::new();
     let r = pairing_batch(&p_vec, &q_vec);
     assert_eq!(r, Fq12::one());
 }
@@ -1125,10 +1125,10 @@ fn test_batch_bilinearity_fifty() {
     ];
     let mut rng = StdRng::from_seed(seed);
 
-    let mut p_vec : Vec<G1> = vec![];
-    let mut q_vec : Vec<G2> = vec![];
-    let mut sp_vec : Vec<G1> = vec![];
-    let mut sq_vec : Vec<G2> = vec![];
+    let mut p_vec : Vec<G1> = Vec::new();
+    let mut q_vec : Vec<G2> = Vec::new();
+    let mut sp_vec : Vec<G1> = Vec::new();
+    let mut sq_vec : Vec<G2> = Vec::new();
     
     for _ in 0..50 {
         let p = G1::random(&mut rng);


### PR DESCRIPTION
This PR allows to load `bn` as `no_std` library. 
In addition it exposes `miller_loop_batch` and `final_exponentiation` functions.