### PR TITLE
update rand package to 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = ["rustc-serialize"]
 name = "api"
 
 [dependencies]
-rand = { version = "0.5", features = ["i128_support"], default-features = false }
+rand = { version = "0.8.3", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
 byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
@@ -24,7 +24,7 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 rustc-hex = { version = "2", default-features = false }
 
 [dev-dependencies]
-rand = { version = "0.5", features = ["i128_support"] }
+rand = { version = "0.8.3", features = ["std_rng"] }
 
 [dev-dependencies.bincode]
 version = "0.6"

--- a/src/fields/tests.rs
+++ b/src/fields/tests.rs
@@ -1,4 +1,4 @@
-use rand::{Rng, SeedableRng, StdRng};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 use super::FieldElement;
 
 fn can_invert<F: FieldElement>() {

--- a/src/groups/mod.rs
+++ b/src/groups/mod.rs
@@ -1096,7 +1096,7 @@ fn test_batch_bilinearity_empty() {
 
 #[test]
 fn test_batch_bilinearity_one() {
-    use rand::{SeedableRng, StdRng};
+    use rand::{SeedableRng, rngs::StdRng};
     let seed = [
         0, 0, 0, 0, 0, 0, 64, 13, // 103245
         0, 0, 0, 0, 0, 0, 176, 2, // 191922
@@ -1116,7 +1116,7 @@ fn test_batch_bilinearity_one() {
 
 #[test]
 fn test_batch_bilinearity_fifty() {
-    use rand::{SeedableRng, StdRng};
+    use rand::{SeedableRng, rngs::StdRng};
     let seed = [
         0, 0, 0, 0, 0, 0, 64, 13, // 103245
         0, 0, 0, 0, 0, 0, 176, 2, // 191922
@@ -1148,7 +1148,7 @@ fn test_batch_bilinearity_fifty() {
 
 #[test]
 fn test_bilinearity() {
-    use rand::{SeedableRng, StdRng};
+    use rand::{SeedableRng, rngs::StdRng};
     let seed = [
         0, 0, 0, 0, 0, 0, 64, 13, // 103245
         0, 0, 0, 0, 0, 0, 176, 2, // 191922

--- a/src/groups/tests.rs
+++ b/src/groups/tests.rs
@@ -90,7 +90,7 @@ pub fn group_trials<G: GroupElement>() {
 
     assert!((G::one() * (-Fr::one()) + G::one()).is_zero());
 
-    use rand::{SeedableRng, StdRng};
+    use rand::{SeedableRng, rngs::StdRng};
     let seed = [
         0, 0, 0, 0, 0, 0, 64, 13, // 103245
         0, 0, 0, 0, 0, 0, 176, 2, // 191922


### PR DESCRIPTION
This PR updates the rand package to 0.8.3, which does not require the i128 support and grabs the StdRng from rand::rngs. 