### PR TITLE
remove rustc-serialize feature and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-bn"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Sean Bowe <ewillbefull@gmail.com>", "Parity Technologies <admin@parity.io>"]
 description = "Pairing cryptography with the Barreto-Naehrig curve"
 keywords = ["pairing","crypto","cryptography"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,3 @@ rustc-hex = { version = "2", default-features = false }
 [dev-dependencies]
 rand = { version = "0.8.3", features = ["std_rng"] }
 
-[dev-dependencies.bincode]
-version = "0.6"
-default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [features]
-default = ["rustc-serialize"]
+default = []
 
 [[bench]]
 name = "api"
 
 [dependencies]
 rand = { version = "0.8.3", default-features = false }
-rustc-serialize = { version = "0.3", optional = true }
 byteorder = { version = "1.0", features = ["i128"], default-features = false }
 crunchy = "0.2.1"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
@@ -30,4 +29,3 @@ rand = { version = "0.8.3", features = ["std_rng"] }
 [dev-dependencies.bincode]
 version = "0.6"
 default-features = false
-features = ["rustc-serialize"]

--- a/benches/api.rs
+++ b/benches/api.rs
@@ -2,7 +2,6 @@
 
 use substrate_bn::*;
 use bincode::SizeLimit::Infinite;
-use bincode::rustc_serialize::{decode, encode};
 
 const SAMPLES: usize = 30;
 
@@ -24,42 +23,6 @@ macro_rules! benchmark(
             });
         }
     )
-);
-
-benchmark!(g1_serialization,
-           input(rng) = G1::random(rng);
-
-           encode(input, Infinite).unwrap()
-);
-
-benchmark!(g1_serialization_normalized,
-           input(rng) = {let mut tmp = G1::random(rng); tmp.normalize(); tmp};
-
-           encode(input, Infinite).unwrap()
-);
-
-benchmark!(g2_serialization,
-           input(rng) = G2::random(rng);
-
-           encode(input, Infinite).unwrap()
-);
-
-benchmark!(g2_serialization_normalized,
-           input(rng) = {let mut tmp = G2::random(rng); tmp.normalize(); tmp};
-
-           encode(input, Infinite).unwrap()
-);
-
-benchmark!(g1_deserialization,
-           input(rng) = {encode(&G1::random(rng), Infinite).unwrap()};
-
-           decode::<G1>(input).unwrap()
-);
-
-benchmark!(g2_deserialization,
-           input(rng) = {encode(&G2::random(rng), Infinite).unwrap()};
-
-           decode::<G2>(input).unwrap()
 );
 
 benchmark!(fr_addition,

--- a/benches/api.rs
+++ b/benches/api.rs
@@ -1,7 +1,6 @@
 #![feature(test)]
 
 use substrate_bn::*;
-use bincode::SizeLimit::Infinite;
 
 const SAMPLES: usize = 30;
 

--- a/src/arith.rs
+++ b/src/arith.rs
@@ -1,8 +1,7 @@
 use core::cmp::Ordering;
 use rand::Rng;
+use crunchy::unroll;
 
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use byteorder::{BigEndian, ByteOrder};
 
 /// 256-bit, stack allocated biginteger for use in prime field
@@ -145,66 +144,6 @@ impl U512 {
         }
 
         U512(n)
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for U512 {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let mut buf = [0; 4 * 16];
-
-        for (l, i) in (0..4).rev().zip((0..4).map(|i| i * 16)) {
-            BigEndian::write_u128(&mut buf[i..], self.0[l]);
-        }
-
-        for i in 0..(4 * 16) {
-            s.emit_u8(buf[i])?;
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Decodable for U512 {
-    fn decode<S: Decoder>(s: &mut S) -> Result<U512, S::Error> {
-        let mut buf = [0; 4 * 16];
-
-        for i in 0..(4 * 16) {
-            buf[i] = s.read_u8()?;
-        }
-
-        Ok(U512::interpret(&buf))
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for U256 {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let mut buf = [0; 2 * 16];
-
-        for (l, i) in (0..2).rev().zip((0..2).map(|i| i * 16)) {
-            BigEndian::write_u128(&mut buf[i..], self.0[l]);
-        }
-
-        for i in 0..(2 * 16) {
-            s.emit_u8(buf[i])?;
-        }
-
-        Ok(())
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Decodable for U256 {
-    fn decode<S: Decoder>(s: &mut S) -> Result<U256, S::Error> {
-        let mut buf = [0; 2 * 16];
-
-        for i in 0..(2 * 16) {
-            buf[i] = s.read_u8()?;
-        }
-
-        U256::from_slice(&buf).map_err(|_| s.error("Invalid input length; Also unreachable;"))
     }
 }
 

--- a/src/fields/fp.rs
+++ b/src/fields/fp.rs
@@ -4,9 +4,6 @@ use rand::Rng;
 use crate::fields::FieldElement;
 use crate::arith::{U256, U512};
 
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-
 macro_rules! field_impl {
     ($name:ident, $modulus:expr, $rsquared:expr, $rcubed:expr, $one:expr, $inv:expr) => {
         #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -19,22 +16,6 @@ macro_rules! field_impl {
                 a.0.mul(&U256::one(), &U256::from($modulus), $inv);
 
                 a.0
-            }
-        }
-
-        #[cfg(feature = "rustc-serialize")]
-        impl Encodable for $name {
-            fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-                let normalized = U256::from(*self);
-
-                normalized.encode(s)
-            }
-        }
-
-        #[cfg(feature = "rustc-serialize")]
-        impl Decodable for $name {
-            fn decode<S: Decoder>(s: &mut S) -> Result<$name, S::Error> {
-                $name::new(U256::decode(s)?).ok_or_else(|| s.error("integer is not less than modulus"))
             }
         }
 
@@ -240,7 +221,7 @@ field_impl!(
     0x9ede7d651eca6ac987d20782e4866389
 );
 
-lazy_static! {
+lazy_static::lazy_static! {
 
     static ref FQ: U256 = U256::from([
         0x3c208c16d87cfd47,

--- a/src/fields/fq2.rs
+++ b/src/fields/fq2.rs
@@ -3,9 +3,6 @@ use rand::Rng;
 use crate::fields::{const_fq, FieldElement, Fq};
 use crate::arith::{U256, U512};
 
-#[cfg(feature = "rustc-serialize")]
-use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-
 #[inline]
 fn fq_non_residue() -> Fq {
     // (q - 1) is a quadratic nonresidue in Fq
@@ -41,28 +38,6 @@ pub fn fq2_nonresidue() -> Fq2 {
 pub struct Fq2 {
     c0: Fq,
     c1: Fq,
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Encodable for Fq2 {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let c0: U256 = self.c0.into();
-        let c1: U256 = self.c1.into();
-
-        U512::new(&c1, &c0, &Fq::modulus()).encode(s)
-    }
-}
-
-#[cfg(feature = "rustc-serialize")]
-impl Decodable for Fq2 {
-    fn decode<S: Decoder>(s: &mut S) -> Result<Fq2, S::Error> {
-        let combined = U512::decode(s)?;
-
-        match combined.divrem(&Fq::modulus()) {
-            (Some(c1), c0) => Ok(Fq2::new(Fq::new(c0).unwrap(), Fq::new(c1).unwrap())),
-            _ => Err(s.error("integer not less than modulus squared")),
-        }
-    }
 }
 
 impl Fq2 {
@@ -206,7 +181,7 @@ impl Neg for Fq2 {
     }
 }
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref FQ: U256 = U256::from([
         0x3c208c16d87cfd47,
         0x97816a916871ca8d,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,6 @@
 #![no_std]
 
-#[cfg_attr(test, macro_use)]
 extern crate alloc;
-extern crate byteorder;
-#[macro_use]
-extern crate crunchy;
-extern crate rand;
-#[cfg(feature = "rustc-serialize")]
-extern crate rustc_serialize;
-#[macro_use] extern crate lazy_static;
 
 pub mod arith;
 mod fields;
@@ -22,7 +14,6 @@ use core::ops::{Add, Mul, Neg, Sub};
 use rand::Rng;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct Fr(fields::Fr);
 
@@ -132,7 +123,6 @@ impl From<FieldError> for CurveError {
 pub use crate::groups::Error as GroupError;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct Fq(fields::Fq);
 
@@ -330,7 +320,6 @@ pub trait Group
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct G1(groups::G1);
 
@@ -442,7 +431,6 @@ impl Mul<Fr> for G1 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct AffineG1(groups::AffineG1);
 
@@ -479,7 +467,6 @@ impl From<AffineG1> for G1 {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct G2(groups::G2);
 
@@ -646,7 +633,6 @@ pub fn miller_loop_batch(pairs: &[(G2, G1)]) -> Result<Gt, CurveError> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcDecodable, RustcEncodable))]
 #[repr(C)]
 pub struct AffineG2(groups::AffineG2);
 
@@ -684,12 +670,11 @@ impl From<AffineG2> for G2 {
 
 #[cfg(test)]
 mod tests {
-    extern crate rustc_hex as hex;
     use alloc::vec::Vec;
     use super::{G1, Fq, G2, Fq2};
 
     fn hex(s: &'static str) -> Vec<u8> {
-        use self::hex::FromHex;
+        use rustc_hex::FromHex;
         s.from_hex().unwrap()
     }
 


### PR DESCRIPTION
I believe `rustc-serialize` is not used anywhere as it was deprecated in favor of serde a few years ago.